### PR TITLE
consumer function response now contained in body

### DIFF
--- a/EventGridConsumer/EventGridFunction/index.js
+++ b/EventGridConsumer/EventGridFunction/index.js
@@ -30,7 +30,7 @@ module.exports = function (context, req) {
         if (eventGridEvent.eventType == SubscriptionValidationEvent) {
             context.log('Got SubscriptionValidation event data, validationCode: ' + eventData.validationCode + ', topic: ' + eventGridEvent.topic); 
             context.res = {
-                    validationResponse: eventData.validationCode
+                body: { "validationResponse": eventData.validationCode }
             };
         } else if (eventGridEvent.eventType == StorageBlobCreatedEvent) {
             context.log('Got Blobcreated event data, blob URI ' + eventData.url);


### PR DESCRIPTION
## Purpose
I couldn't get consumer function to subscribe to event grid. Miving the validationResponse into the response body fixed it.

## Does this introduce a breaking change?
```
[ ] Yes
[x ] No
```

## Pull Request Type

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


